### PR TITLE
Update warning for Reprint Cert - no signature batch request

### DIFF
--- a/frontend/src/components/Batch/Batch.vue
+++ b/frontend/src/components/Batch/Batch.vue
@@ -1454,12 +1454,15 @@ export default {
           }
           //disable code for release 1.7.0
           this.batchTypes = this.batchTypes.map((type) => {
-            if (type.code === "ARC_STUDENTS" || type.code === "ARC_SCH_REPORTS") {
+            if (
+              type.code === "ARC_STUDENTS" ||
+              type.code === "ARC_SCH_REPORTS"
+            ) {
               type.disabled = true;
             }
             return type;
-          });         
-                  
+          });
+
           if (!this.allowRunNonGradRun)
             this.batchTypes = this.batchTypes.filter(
               (type) => type.code != "NONGRADRUN"
@@ -1709,8 +1712,15 @@ export default {
                 } else {
                   //student has a gradstatus but does not have a certificate
                   if (this.batch.details["credential"] == "RC") {
-                    this.validationMessage =
-                      "Cannot reprint certificate for this student.";
+                    if (this.batch.details["where"] == "localDownload") {
+                      this.validationMessage =
+                        "This students' certificate distribution date is null. Their original certificate has not been distributed. You may still download the requested document by clicking on the link below.";
+                    } else {
+                      // NOTE - When users can eventually select the BC Mail or User:[name] options for reprint certificate - no principal signature block, the warning below should be updated to:
+                      // This students' certificate distribution date is null. Their original certificate has not been distributed. You may still submit a print request by clicking on the link below.
+                      this.validationMessage =
+                        "Cannot reprint certificate for this student.";
+                    }
                   }
                   if (this.batch.details["credential"] == "OC") {
                     this.validationMessage =


### PR DESCRIPTION
Ticket - https://eccbc.atlassian.net/browse/GRAD2-2301

Note - I didn't add the message for item 2 in JM's comment since we don't have the ability for users to select BC Mail or User:[name] options if the student has a null certificate distribution date. I left a comment explaining this instead and will follow up with business.