### PR TITLE
Fix for INFO HPA alerts.

### DIFF
--- a/.github/workflows/build-n-deploy-backend-km.yml
+++ b/.github/workflows/build-n-deploy-backend-km.yml
@@ -34,7 +34,7 @@ env:
   MIN_MEM: "200Mi"
   MAX_MEM: "250Mi"
   MIN_REPLICAS: "1"
-  MAX_REPLICAS: "1"
+  MAX_REPLICAS: "2"
 
   # SITE_URL should have no scheme or port. It will be prepended with https://
   HOST_ROUTE: ${{ secrets.SITE_URL }}

--- a/.github/workflows/build-n-deploy-backend-to-ocp-dev-vue3.yml
+++ b/.github/workflows/build-n-deploy-backend-to-ocp-dev-vue3.yml
@@ -34,7 +34,7 @@ env:
   MIN_MEM: "200Mi"
   MAX_MEM: "250Mi"
   MIN_REPLICAS: "1"
-  MAX_REPLICAS: "1"
+  MAX_REPLICAS: "2"
 
   # SITE_URL should have no scheme or port. It will be prepended with https://
   HOST_ROUTE: ${{ secrets.SITE_URL }}

--- a/.github/workflows/build-n-deploy-backend-to-ocp-dev.yml
+++ b/.github/workflows/build-n-deploy-backend-to-ocp-dev.yml
@@ -34,7 +34,7 @@ env:
   MIN_MEM: "200Mi"
   MAX_MEM: "250Mi"
   MIN_REPLICAS: "1"
-  MAX_REPLICAS: "1"
+  MAX_REPLICAS: "2"
 
   # SITE_URL should have no scheme or port. It will be prepended with https://
   HOST_ROUTE: ${{ secrets.SITE_URL }}

--- a/.github/workflows/build-n-deploy-backend-to-ocp-tools.yml
+++ b/.github/workflows/build-n-deploy-backend-to-ocp-tools.yml
@@ -34,7 +34,7 @@ env:
   MIN_MEM: "200Mi"
   MAX_MEM: "250Mi"
   MIN_REPLICAS: "1"
-  MAX_REPLICAS: "1"
+  MAX_REPLICAS: "2"
 
   # SITE_URL should have no scheme or port. It will be prepended with https://
   HOST_ROUTE: ${{ secrets.SITE_URL }}

--- a/.github/workflows/deploy-backend-to-ocp-test.yml
+++ b/.github/workflows/deploy-backend-to-ocp-test.yml
@@ -38,7 +38,7 @@ env:
   MIN_MEM: "200Mi"
   MAX_MEM: "250Mi"
   MIN_REPLICAS: "3"
-  MAX_REPLICAS: "3"
+  MAX_REPLICAS: "5"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-frontend-to-ocp-test.yml
+++ b/.github/workflows/deploy-frontend-to-ocp-test.yml
@@ -34,7 +34,7 @@ env:
   MIN_MEM: "200Mi"
   MAX_MEM: "250Mi"
   MIN_REPLICAS: "3"
-  MAX_REPLICAS: "3"
+  MAX_REPLICAS: "5"
 
   # SITE_URL should have no scheme or port. It will be prepended with https://
   HOST_ROUTE: ${{ secrets.SITE_URL }}


### PR DESCRIPTION
In response to OCIO alerts triggered when an HPA has no variance between min and max pods in a pod disruption budget.